### PR TITLE
feat: add route:list command and HelperCommandsProvider

### DIFF
--- a/providers/HelperCommandsProvider.js
+++ b/providers/HelperCommandsProvider.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const ServiceProvider = require('adonis-fold').ServiceProvider
+
+class HelperCommandsProvider extends ServiceProvider {
+
+  * register () {
+  	//Route:List command
+    this.app.bind('Adonis/Commands/Route:List', (app) => {
+      const RouteList = require('../src/RouteList')
+      const Helpers = app.use('Adonis/Src/Helpers')
+      return new RouteList(Helpers)
+    })
+  }
+
+}
+
+module.exports = HelperCommandsProvider

--- a/providers/HelperCommandsProvider.js
+++ b/providers/HelperCommandsProvider.js
@@ -8,8 +8,10 @@ class HelperCommandsProvider extends ServiceProvider {
   	//Route:List command
     this.app.bind('Adonis/Commands/Route:List', (app) => {
       const RouteList = require('../src/RouteList')
+      
       const Helpers = app.use('Adonis/Src/Helpers')
-      return new RouteList(Helpers)
+      const Route = app.use('Adonis/Src/Route')
+      return new RouteList(Route, Helpers)
     })
   }
 

--- a/src/RouteList.js
+++ b/src/RouteList.js
@@ -35,7 +35,7 @@ class RouteList extends Command {
   			route.domain || '',
   			route.verb.join('|') || '',
         route.route || '',
-  			(route.handler.constructor === String ? route.handler : 'Function'),
+  			(route.handler.constructor === String ? route.handler : 'Closure'),
   			route.middlewares.join('|') || '',
   			route.name || ''
   		]

--- a/src/RouteList.js
+++ b/src/RouteList.js
@@ -1,13 +1,16 @@
 'use strict'
 
+const path = require('path')
 const Ioc = require('adonis-fold').Ioc
 const Command = Ioc.use('Adonis/Src/Command')
-const Route = Ioc.use('Adonis/Src/Route')
+
 
 class RouteList extends Command {
 
-  constructor (Helpers) {
+  constructor (Route, Helpers) {
     super()
+
+    this.route = Route
     this.helpers = Helpers
   }
 
@@ -20,19 +23,19 @@ class RouteList extends Command {
   }
 
   setup(){
-      //Require the app/Http/routes.js to know what routes are registered
-      require(this.helpers.appPath()+'/Http/routes.js')
+      require(path.join(this.helpers.appPath(), 'Http/routes.js'))
       
-      this.routes = Route.routes()
       this.parsedRoutesList = []
   }
 
   _parseRoutes() {
-  	this.parsedRoutesList = this.routes.map(function(route){
+  	this.parsedRoutesList = this.route.routes().map(function(route){
+
 		return [
   			route.domain || '',
   			route.verb.join('|') || '',
-  			route.route || '',
+        route.route || '',
+  			(route.handler.constructor === String ? route.handler : 'Function'),
   			route.middlewares.join('|') || '',
   			route.name || ''
   		]
@@ -44,7 +47,7 @@ class RouteList extends Command {
   * handle (args, options) {
 
   	this.table(
-      ['Domain','Method','URI','Middlewares','Name'], 
+      ['Domain','Method','URI','Action','Middlewares','Name'], 
       this._parseRoutes()
     )
   }

--- a/src/RouteList.js
+++ b/src/RouteList.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const Ioc = require('adonis-fold').Ioc
+const Command = Ioc.use('Adonis/Src/Command')
+const Route = Ioc.use('Adonis/Src/Route')
+
+class RouteList extends Command {
+
+  constructor (Helpers) {
+    super()
+    this.helpers = Helpers
+  }
+
+  get signature () {
+    return 'route:list'
+  }
+
+  get description () {
+    return 'List all Routes registered for this app'
+  }
+
+  setup(){
+      //Require the app/Http/routes.js to know what routes are registered
+      require(this.helpers.appPath()+'/Http/routes.js')
+      
+      this.routes = Route.routes()
+      this.parsedRoutesList = []
+  }
+
+  _parseRoutes() {
+  	this.parsedRoutesList = this.routes.map(function(route){
+		return [
+  			route.domain || '',
+  			route.verb.join('|') || '',
+  			route.route || '',
+  			route.middlewares.join('|') || '',
+  			route.name || ''
+  		]
+  	})
+
+  	return this.parsedRoutesList
+  }
+
+  * handle (args, options) {
+
+  	this.table(
+      ['Domain','Method','URI','Middlewares','Name'], 
+      this._parseRoutes()
+    )
+  }
+
+}
+
+module.exports = RouteList


### PR DESCRIPTION
This PR adds a `route:list` command to the list of default commands of adonis-commands package.
And also a `HelperCommandsProvider`, this is for all new default helper commands, be called in one provider only.

Changes needed on [adonisjs/adonis-app](https://github.com/adonisjs/adonis-app) if this PR is accepted:

**file:** `bootstrap/app.js`

``` javascript

const aceProviders = [
     ...,
    'adonis-commands/providers/HelperCommandsProvider'
]

const commands = [
     ...,
    'Adonis/Commands/Route:List'
]
```

After executing the `./ace route:list` command, it will generate the table on the image below, with all your registered routes on the `app/Http/routes.js` file.

![adonis-commands-routelist-034827348723](https://cloud.githubusercontent.com/assets/304086/18234678/1d97d8d4-72e3-11e6-8b42-94a6518f08a8.png)
