### PR TITLE
feat: Adds echo option for echoing key:generate

### DIFF
--- a/src/Generators/Key.js
+++ b/src/Generators/Key.js
@@ -15,7 +15,7 @@ const path = require('path')
 class KeyGenerator extends BaseGenerator {
 
   get signature () {
-    return 'key:generate {-f,--force?} {-e,--env=@value} {-s,--size=@value}'
+    return 'key:generate {-f,--force?} {-e,--env=@value} {-s,--size=@value} {--echo?}'
   }
 
   get description () {
@@ -37,8 +37,13 @@ class KeyGenerator extends BaseGenerator {
     const size = options.size || 32
     const pathToEnv = path.isAbsolute(env) ? env : path.join(this.helpers.basePath(), env)
     let parsedValues = yield this._getContents(pathToEnv)
+    const key = this.randomString.generate(size)
+
+    if (options.echo) {
+      return this.success(`APP_KEY=${key}`)
+    }
     parsedValues = this.dotEnv.parse(parsedValues)
-    parsedValues.APP_KEY = this.randomString.generate(size)
+    parsedValues.APP_KEY = key
     Object.keys(parsedValues).forEach(function (item) {
       envContents += `${item}=${parsedValues[item]}\n`
     })


### PR DESCRIPTION
This adds a `--echo` option to the `key:generate` command.

The purpose of this is for things like Heroku or applications that do not use `.env` because of distributed or incidental systems where true environment variables are used instead.

For instance right now to generate a key for prod environments on Heroku, Doku, or other I would have to `./ace key:generate` then go into the `.env` file and pull the value from this file.
But, this has two consequences:

* It adds a step for getting the new generated key
* It removes the old value from ENV which is hard to recover leading to development sessions, JWTs, and ecoded values being lost and unrecoverable.

With this PR, running `./ace key:generate --echo` will output `APP_KEY=w6Vo3vgCUMKm0B19Z186P140kvwzhwjb` or similar.

This is similar to the key generator in Phoenix allowing for quick use wherever needed while also keeping existing behavior.